### PR TITLE
Use sync method "users_groups" as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Flags:
       --include-groups strings      include only these Google groups
       --log-format string           log format (default "text")
       --log-level string            log level (default "info")
-  -s, --sync-method string          Select the sync method to use (users_groups|groups) (default "groups")
+  -s, --sync-method string          Select the sync method to use (users_groups|groups) (default "user_groups")
   -m, --user-match string           Google users query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users
   -v, --version                     version for ssosync
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,7 +43,7 @@ const (
 	// DefaultGoogleCredentials is the default credentials path
 	DefaultGoogleCredentials = "credentials.json"
 	// DefaultSyncMethod is the default sync method to use.
-	DefaultSyncMethod = "groups"
+	DefaultSyncMethod = "users_groups"
 )
 
 // New returns a new Config

--- a/internal/google/client.go
+++ b/internal/google/client.go
@@ -97,11 +97,18 @@ func (c *client) GetGroupMembers(g *admin.Group) ([]*admin.Member, error) {
 //  EmploymentData.projects:'GeneGnomes'
 func (c *client) GetUsers(query string) ([]*admin.User, error) {
 	u := make([]*admin.User, 0)
-	err := c.service.Users.List().Query(query).Customer("my_customer").Pages(c.ctx, func(users *admin.Users) error {
-		u = append(u, users.Users...)
-		return nil
-	})
-
+	var err error
+	if len(query) == 0 {
+		err = c.service.Users.List().Customer("my_customer").Pages(c.ctx, func(users *admin.Users) error {
+			u = append(u, users.Users...)
+			return nil
+		})
+	} else {
+		err = c.service.Users.List().Query(query).Customer("my_customer").Pages(c.ctx, func(users *admin.Users) error {
+			u = append(u, users.Users...)
+			return nil
+		})
+	}
 	return u, err
 }
 
@@ -119,10 +126,17 @@ func (c *client) GetUsers(query string) ([]*admin.User, error) {
 //  email:aws-*
 func (c *client) GetGroups(query string) ([]*admin.Group, error) {
 	g := make([]*admin.Group, 0)
-	err := c.service.Groups.List().Customer("my_customer").Query(query).Pages(context.TODO(), func(groups *admin.Groups) error {
-		g = append(g, groups.Groups...)
-		return nil
-	})
-
+	var err error
+	if len(query) == 0 {
+		err = c.service.Groups.List().Customer("my_customer").Pages(context.TODO(), func(groups *admin.Groups) error {
+			g = append(g, groups.Groups...)
+			return nil
+		})
+	} else {
+		err = c.service.Groups.List().Customer("my_customer").Query(query).Pages(context.TODO(), func(groups *admin.Groups) error {
+			g = append(g, groups.Groups...)
+			return nil
+		})
+	}
 	return g, err
 }

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -8,4 +8,4 @@ s3_prefix = "ssosync-lambda"
 region = "eu-west-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "ScheduleExpression=\"rate(15 minutes)\" LogLevel=\"warn\" LogFormat=\"json\" GoogleUserMatch=\"\" GoogleGroupMatch=\"\" SyncMethod=\"groups\""
+parameter_overrides = "ScheduleExpression=\"rate(30 minutes)\" LogLevel=\"warn\" LogFormat=\"json\" GoogleUserMatch=\"\" GoogleGroupMatch=\"\" SyncMethod=\"users_groups\""


### PR DESCRIPTION
This PR is based on the latest release https://github.com/awslabs/ssosync/releases/tag/v1.0.0-rc.9, however -
- It sets the default sync methods to `users_groups` to use `SyncUsers` and `SyncGroups` as we're currently using now. It doesn't use the new `SyncGroupsUsers(cfg.GroupMatch)` method, I'm not confident this works for our case for now.
- rc.9 introduces the google group and user query, however it doesn't handle the edge cases. This PR fixes the app crash issue when an empty string is sent to google api query.

Running it locally:
```
go run main.go
  --access-token "some string" \
  --debug \
  --endpoint "some string" \
  --google-admin "some string" \
  --google-credentials "credentials.json" \
  --include-groups "satellite@acast.com,a-team@acast.com,steel@acast.com,fortune@acast.com..." \
  --ignore-groups "some string"
```