### PR TITLE
Update yaml to retrieve secrets from secrets manager

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,7 @@ func initConfig() {
 		"log_format",
 		"ignore_users",
 		"ignore_groups",
+		"include_groups",
 		"user_match",
 		"group_match",
 		"sync_method",

--- a/template.yaml
+++ b/template.yaml
@@ -5,13 +5,6 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "General"
-        Parameters:
-          - GoogleCredentials
-          - GoogleAdminEmail
-          - SCIMEndpointUrl
-          - SCIMEndpointAccessToken
-      - Label:
           default: "Advanced Configuration"
         Parameters:
           - SyncMethod
@@ -20,6 +13,8 @@ Metadata:
           - LogLevel
           - LogFormat
           - ScheduleExpression
+          - IgnoreGroups
+          - IncludeGroups
 
   AWS::ServerlessRepo::Application:
     Name: ssosync
@@ -60,22 +55,6 @@ Parameters:
     AllowedValues:
       - json
       - text
-  GoogleCredentials:
-    Type: String
-    Description: Credentials to log into Google (content of credentials.json)
-    NoEcho: true
-  GoogleAdminEmail:
-    Type: String
-    Description: Google Admin email
-    NoEcho: true
-  SCIMEndpointUrl:
-    Type: String
-    Description: AWS SSO SCIM Endpoint Url
-    NoEcho: true
-  SCIMEndpointAccessToken:
-    Type: String
-    Description: AWS SSO SCIM AccessToken
-    NoEcho: true
   GoogleUserMatch:
     Type: String
     Description: |
@@ -91,6 +70,12 @@ Parameters:
     AllowedValues:
       - groups
       - users_groups
+  IgnoreGroups:
+    Type: String
+    Description: Ignores these Google groups, separated by comma
+  IncludeGroups:
+    Type: String
+    Description: Include only these Google groups, separated by comma
 
 Resources:
   SSOSyncFunction:
@@ -103,13 +88,15 @@ Resources:
         Variables:
           SSOSYNC_LOG_LEVEL: !Ref LogLevel
           SSOSYNC_LOG_FORMAT: !Ref LogFormat
-          SSOSYNC_GOOGLE_CREDENTIALS: !Ref AWSGoogleCredentialsSecret
-          SSOSYNC_GOOGLE_ADMIN: !Ref AWSGoogleAdminEamil
-          SSOSYNC_SCIM_ENDPOINT: !Ref AWSSCIMEndpointSecret
-          SSOSYNC_SCIM_ACCESS_TOKEN: !Ref AWSSCIMAccessTokenSecret
+          SSOSYNC_GOOGLE_CREDENTIALS: '{{resolve:secretsmanager:SSOSyncGoogleCredentials}}'
+          SSOSYNC_GOOGLE_ADMIN: '{{resolve:secretsmanager:SSOSyncGoogleAdminEmail}}'
+          SSOSYNC_SCIM_ENDPOINT: '{{resolve:secretsmanager:SSOSyncSCIMEndpointUrl}}'
+          SSOSYNC_SCIM_ACCESS_TOKEN: '{{resolve:secretsmanager:SSOSyncSCIMAccessToken}}'
           SSOSYNC_USER_MATCH: !Ref GoogleUserMatch
           SSOSYNC_GROUP_MATCH: !Ref GoogleGroupMatch
           SSOSYNC_SYNC_METHOD: !Ref SyncMethod
+          SSOSYNC_IGNORE_GROUPS: !Ref IgnoreGroups
+          SSOSYNC_INCLUDE_GROUPS: !Ref IncludeGroups
       Policies:
         - Statement:
             - Sid: SSMGetParameterPolicy
@@ -117,10 +104,7 @@ Resources:
               Action:
                 - "secretsmanager:Get*"
               Resource:
-                - !Ref AWSGoogleCredentialsSecret
-                - !Ref AWSGoogleAdminEamil
-                - !Ref AWSSCIMEndpointSecret
-                - !Ref AWSSCIMAccessTokenSecret
+                - "*"
       Events:
         SyncScheduledEvent:
           Type: Schedule
@@ -128,27 +112,3 @@ Resources:
           Properties:
             Enabled: true
             Schedule: !Ref ScheduleExpression
-
-  AWSGoogleCredentialsSecret:
-    Type: "AWS::SecretsManager::Secret"
-    Properties:
-      Name: SSOSyncGoogleCredentials
-      SecretString: !Ref GoogleCredentials
-
-  AWSGoogleAdminEamil:
-    Type: "AWS::SecretsManager::Secret"
-    Properties:
-      Name: SSOSyncGoogleAdminEmail
-      SecretString: !Ref GoogleAdminEmail
-
-  AWSSCIMEndpointSecret: # This can be moved to custom provider
-    Type: "AWS::SecretsManager::Secret"
-    Properties:
-      Name: SSOSyncSCIMEndpointUrl
-      SecretString: !Ref SCIMEndpointUrl
-
-  AWSSCIMAccessTokenSecret: # This can be moved to custom provider
-    Type: "AWS::SecretsManager::Secret"
-    Properties:
-      Name: SSOSyncSCIMAccessToken
-      SecretString: !Ref SCIMEndpointAccessToken


### PR DESCRIPTION
In SAM deploy:
- retrieve existing secrets from secrets manager instead of creating them during deployment
- add parameters `IgnoreGroups` and `IncludeGroups`

Also updated appEnvVars to include `include-groups`.