### PR TITLE
Feature: Archived users treated as suspended users

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -121,7 +121,7 @@ func (s *syncGSuite) SyncUsers(query string) error {
 		if uu != nil {
 			s.users[uu.Username] = uu
 			// Update the user when suspended state is changed
-			if uu.Active == u.Suspended {
+			if uu.Active == u.Suspended || uu.Active == u.Archived {
 				log.Debug("Mismatch active/suspended, updating user")
 				// create new user object and update the user
 				_, err := s.aws.UpdateUser(aws.UpdateUser(

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -122,7 +122,7 @@ func (s *syncGSuite) SyncUsers(query string) error {
 			s.users[uu.Username] = uu
 			// Update the user when suspended state is changed
 			if uu.Active == u.Suspended || uu.Active == u.Archived {
-				log.WithField("Name", u).Info("Mismatch active/suspended, updating user")
+				log.Debug("Mismatch active/suspended, updating user")
 				// create new user object and update the user
 				_, err := s.aws.UpdateUser(aws.UpdateUser(
 					uu.ID,

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -122,14 +122,14 @@ func (s *syncGSuite) SyncUsers(query string) error {
 			s.users[uu.Username] = uu
 			// Update the user when suspended state is changed
 			if uu.Active == u.Suspended || uu.Active == u.Archived {
-				log.Debug("Mismatch active/suspended, updating user")
+				log.WithField("Name", u).Info("Mismatch active/suspended, updating user")
 				// create new user object and update the user
 				_, err := s.aws.UpdateUser(aws.UpdateUser(
 					uu.ID,
 					u.Name.GivenName,
 					u.Name.FamilyName,
 					u.PrimaryEmail,
-					!u.Suspended))
+					!uu.Active))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Made use of the `archived` flag on Google users to set users as inactive in accordance with how Internal IT uses archiving.